### PR TITLE
Removed the internal ethNetworkName field from the config

### DIFF
--- a/shared/config/ids/hyperdrive.go
+++ b/shared/config/ids/hyperdrive.go
@@ -5,7 +5,6 @@ const (
 	RootConfigID               string = "hyperdrive"
 	VersionID                  string = "version"
 	UserDirID                  string = "hdUserDir"
-	EthNetworkNameID           string = "ethNetworkName"
 	ApiPortID                  string = "apiPort"
 	NetworkID                  string = "network"
 	EnableIPv6ID               string = "enableIPv6"

--- a/shared/version.go
+++ b/shared/version.go
@@ -1,5 +1,5 @@
 package shared
 
 const (
-	HyperdriveVersion string = "1.1.0-b1"
+	HyperdriveVersion string = "1.1.0-dev"
 )


### PR DESCRIPTION
This removes the old `ethNetworkName` field from the Hyperdrive config. It isn't used anymore now that we have the disk-based network resources system, and it was causing confusion down the line since the ETH network name could live in multiple places. 