### PR TITLE
Move deployments into modules

### DIFF
--- a/client/nodeset-constellation.go
+++ b/client/nodeset-constellation.go
@@ -32,20 +32,25 @@ func (r *NodeSetConstellationRequester) GetContext() client.IRequesterContext {
 }
 
 // Gets the address the node's user has assigned as the registered Constellation address
-func (r *NodeSetConstellationRequester) GetRegisteredAddress() (*types.ApiResponse[api.NodeSetConstellation_GetRegisteredAddressData], error) {
-	args := map[string]string{}
+func (r *NodeSetConstellationRequester) GetRegisteredAddress(deployment string) (*types.ApiResponse[api.NodeSetConstellation_GetRegisteredAddressData], error) {
+	args := map[string]string{
+		"deployment": deployment,
+	}
 	return client.SendGetRequest[api.NodeSetConstellation_GetRegisteredAddressData](r, "get-registered-address", "GetRegisteredAddress", args)
 }
 
 // Gets a signature for registering / whitelisting the node with the Constellation contracts
-func (r *NodeSetConstellationRequester) GetRegistrationSignature() (*types.ApiResponse[api.NodeSetConstellation_GetRegistrationSignatureData], error) {
-	args := map[string]string{}
+func (r *NodeSetConstellationRequester) GetRegistrationSignature(deployment string) (*types.ApiResponse[api.NodeSetConstellation_GetRegistrationSignatureData], error) {
+	args := map[string]string{
+		"deployment": deployment,
+	}
 	return client.SendGetRequest[api.NodeSetConstellation_GetRegistrationSignatureData](r, "get-registration-signature", "GetRegistrationSignature", args)
 }
 
 // Gets the deposit signature for a minipool from the Constellation contracts
-func (r *NodeSetConstellationRequester) GetDepositSignature(minipoolAddress common.Address, salt *big.Int) (*types.ApiResponse[api.NodeSetConstellation_GetDepositSignatureData], error) {
+func (r *NodeSetConstellationRequester) GetDepositSignature(deployment string, minipoolAddress common.Address, salt *big.Int) (*types.ApiResponse[api.NodeSetConstellation_GetDepositSignatureData], error) {
 	args := map[string]string{
+		"deployment":      deployment,
 		"minipoolAddress": minipoolAddress.Hex(),
 		"salt":            salt.String(),
 	}
@@ -53,14 +58,17 @@ func (r *NodeSetConstellationRequester) GetDepositSignature(minipoolAddress comm
 }
 
 // Gets the validators that have been registered with the NodeSet service for this node as part of Constellation
-func (r *NodeSetConstellationRequester) GetValidators() (*types.ApiResponse[api.NodeSetConstellation_GetValidatorsData], error) {
-	args := map[string]string{}
+func (r *NodeSetConstellationRequester) GetValidators(deployment string) (*types.ApiResponse[api.NodeSetConstellation_GetValidatorsData], error) {
+	args := map[string]string{
+		"deployment": deployment,
+	}
 	return client.SendGetRequest[api.NodeSetConstellation_GetValidatorsData](r, "get-validators", "GetValidators", args)
 }
 
 // Uploads signed exit messages to the NodeSet service
-func (r *NodeSetConstellationRequester) UploadSignedExits(exitMessages []nscommon.ExitData) (*types.ApiResponse[api.NodeSetConstellation_UploadSignedExitsData], error) {
+func (r *NodeSetConstellationRequester) UploadSignedExits(deployment string, exitMessages []nscommon.ExitData) (*types.ApiResponse[api.NodeSetConstellation_UploadSignedExitsData], error) {
 	body := api.NodeSetConstellation_UploadSignedExitsRequestBody{
+		Deployment:   deployment,
 		ExitMessages: exitMessages,
 	}
 	return client.SendPostRequest[api.NodeSetConstellation_UploadSignedExitsData](r, "upload-signed-exits", "UploadSignedExits", body)

--- a/client/nodeset-stakewise.go
+++ b/client/nodeset-stakewise.go
@@ -31,32 +31,36 @@ func (r *NodeSetStakeWiseRequester) GetContext() client.IRequesterContext {
 }
 
 // Gets the list of validators that the node has registered with the provided vault
-func (r *NodeSetStakeWiseRequester) GetRegisteredValidators(vault common.Address) (*types.ApiResponse[api.NodeSetStakeWise_GetRegisteredValidatorsData], error) {
+func (r *NodeSetStakeWiseRequester) GetRegisteredValidators(deployment string, vault common.Address) (*types.ApiResponse[api.NodeSetStakeWise_GetRegisteredValidatorsData], error) {
 	args := map[string]string{
-		"vault": vault.Hex(),
+		"deployment": deployment,
+		"vault":      vault.Hex(),
 	}
 	return client.SendGetRequest[api.NodeSetStakeWise_GetRegisteredValidatorsData](r, "get-registered-validators", "GetRegisteredValidators", args)
 }
 
 // Gets the version of the latest deposit data set on the server for the provided vault
-func (r *NodeSetStakeWiseRequester) GetDepositDataSetVersion(vault common.Address) (*types.ApiResponse[api.NodeSetStakeWise_GetDepositDataSetVersionData], error) {
+func (r *NodeSetStakeWiseRequester) GetDepositDataSetVersion(deployment string, vault common.Address) (*types.ApiResponse[api.NodeSetStakeWise_GetDepositDataSetVersionData], error) {
 	args := map[string]string{
-		"vault": vault.Hex(),
+		"deployment": deployment,
+		"vault":      vault.Hex(),
 	}
 	return client.SendGetRequest[api.NodeSetStakeWise_GetDepositDataSetVersionData](r, "get-deposit-data-set/version", "GetDepositDataSetVersion", args)
 }
 
 // Gets the latest deposit data set on the server for the provided vault
-func (r *NodeSetStakeWiseRequester) GetDepositDataSet(vault common.Address) (*types.ApiResponse[api.NodeSetStakeWise_GetDepositDataSetData], error) {
+func (r *NodeSetStakeWiseRequester) GetDepositDataSet(deployment string, vault common.Address) (*types.ApiResponse[api.NodeSetStakeWise_GetDepositDataSetData], error) {
 	args := map[string]string{
-		"vault": vault.Hex(),
+		"deployment": deployment,
+		"vault":      vault.Hex(),
 	}
 	return client.SendGetRequest[api.NodeSetStakeWise_GetDepositDataSetData](r, "get-deposit-data-set", "GetDepositDataSet", args)
 }
 
 // Uploads new validator deposit data to the NodeSet service
-func (r *NodeSetStakeWiseRequester) UploadDepositData(vault common.Address, data []beacon.ExtendedDepositData) (*types.ApiResponse[api.NodeSetStakeWise_UploadDepositDataData], error) {
+func (r *NodeSetStakeWiseRequester) UploadDepositData(deployment string, vault common.Address, data []beacon.ExtendedDepositData) (*types.ApiResponse[api.NodeSetStakeWise_UploadDepositDataData], error) {
 	body := api.NodeSetStakeWise_UploadDepositDataRequestBody{
+		Deployment:  deployment,
 		Vault:       vault,
 		DepositData: data,
 	}
@@ -64,10 +68,11 @@ func (r *NodeSetStakeWiseRequester) UploadDepositData(vault common.Address, data
 }
 
 // Uploads signed exit messages to the NodeSet service
-func (r *NodeSetStakeWiseRequester) UploadSignedExits(vault common.Address, data []nscommon.ExitData) (*types.ApiResponse[api.NodeSetStakeWise_UploadSignedExitsData], error) {
+func (r *NodeSetStakeWiseRequester) UploadSignedExits(deployment string, vault common.Address, data []nscommon.ExitData) (*types.ApiResponse[api.NodeSetStakeWise_UploadSignedExitsData], error) {
 	body := api.NodeSetStakeWise_UploadSignedExitsRequestBody{
-		Vault:    vault,
-		ExitData: data,
+		Deployment: deployment,
+		Vault:      vault,
+		ExitData:   data,
 	}
 	return client.SendPostRequest[api.NodeSetStakeWise_UploadSignedExitsData](r, "upload-signed-exits", "UploadSignedExits", body)
 }

--- a/common/nodeset-manager.go
+++ b/common/nodeset-manager.go
@@ -131,7 +131,7 @@ func (m *NodeSetServiceManager) RegisterNode(ctx context.Context, email string) 
 // =========================
 
 // Get the version of the latest deposit data set from the server
-func (m *NodeSetServiceManager) StakeWise_GetServerDepositDataVersion(ctx context.Context, vault common.Address) (int, error) {
+func (m *NodeSetServiceManager) StakeWise_GetServerDepositDataVersion(ctx context.Context, deployment string, vault common.Address) (int, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -146,7 +146,7 @@ func (m *NodeSetServiceManager) StakeWise_GetServerDepositDataVersion(ctx contex
 	var data stakewise.DepositDataMetaData
 	err := m.runRequest(ctx, func(ctx context.Context) error {
 		var err error
-		data, err = m.v2Client.StakeWise.DepositDataMeta(ctx, logger.Logger, m.resources.DeploymentName, vault)
+		data, err = m.v2Client.StakeWise.DepositDataMeta(ctx, logger.Logger, deployment, vault)
 		return err
 	})
 	if err != nil {
@@ -156,7 +156,7 @@ func (m *NodeSetServiceManager) StakeWise_GetServerDepositDataVersion(ctx contex
 }
 
 // Get the deposit data set from the server
-func (m *NodeSetServiceManager) StakeWise_GetServerDepositData(ctx context.Context, vault common.Address) (int, []beacon.ExtendedDepositData, error) {
+func (m *NodeSetServiceManager) StakeWise_GetServerDepositData(ctx context.Context, deployment string, vault common.Address) (int, []beacon.ExtendedDepositData, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -171,7 +171,7 @@ func (m *NodeSetServiceManager) StakeWise_GetServerDepositData(ctx context.Conte
 	var data stakewise.DepositDataData
 	err := m.runRequest(ctx, func(ctx context.Context) error {
 		var err error
-		data, err = m.v2Client.StakeWise.DepositData_Get(ctx, logger.Logger, m.resources.DeploymentName, vault)
+		data, err = m.v2Client.StakeWise.DepositData_Get(ctx, logger.Logger, deployment, vault)
 		return err
 	})
 	if err != nil {
@@ -181,7 +181,7 @@ func (m *NodeSetServiceManager) StakeWise_GetServerDepositData(ctx context.Conte
 }
 
 // Uploads local deposit data set to the server
-func (m *NodeSetServiceManager) StakeWise_UploadDepositData(ctx context.Context, vault common.Address, depositData []beacon.ExtendedDepositData) error {
+func (m *NodeSetServiceManager) StakeWise_UploadDepositData(ctx context.Context, deployment string, vault common.Address, depositData []beacon.ExtendedDepositData) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -194,7 +194,7 @@ func (m *NodeSetServiceManager) StakeWise_UploadDepositData(ctx context.Context,
 
 	// Run the request
 	err := m.runRequest(ctx, func(ctx context.Context) error {
-		return m.v2Client.StakeWise.DepositData_Post(ctx, logger.Logger, m.resources.DeploymentName, vault, depositData)
+		return m.v2Client.StakeWise.DepositData_Post(ctx, logger.Logger, deployment, vault, depositData)
 	})
 	if err != nil {
 		return fmt.Errorf("error uploading deposit data: %w", err)
@@ -203,7 +203,7 @@ func (m *NodeSetServiceManager) StakeWise_UploadDepositData(ctx context.Context,
 }
 
 // Get the version of the latest deposit data set from the server
-func (m *NodeSetServiceManager) StakeWise_GetRegisteredValidators(ctx context.Context, vault common.Address) ([]stakewise.ValidatorStatus, error) {
+func (m *NodeSetServiceManager) StakeWise_GetRegisteredValidators(ctx context.Context, deployment string, vault common.Address) ([]stakewise.ValidatorStatus, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -218,7 +218,7 @@ func (m *NodeSetServiceManager) StakeWise_GetRegisteredValidators(ctx context.Co
 	var data stakewise.ValidatorsData
 	err := m.runRequest(ctx, func(ctx context.Context) error {
 		var err error
-		data, err = m.v2Client.StakeWise.Validators_Get(ctx, logger.Logger, m.resources.DeploymentName, vault)
+		data, err = m.v2Client.StakeWise.Validators_Get(ctx, logger.Logger, deployment, vault)
 		return err
 	})
 	if err != nil {
@@ -228,7 +228,7 @@ func (m *NodeSetServiceManager) StakeWise_GetRegisteredValidators(ctx context.Co
 }
 
 // Uploads signed exit messages set to the server
-func (m *NodeSetServiceManager) StakeWise_UploadSignedExitMessages(ctx context.Context, vault common.Address, exitData []nscommon.ExitData) error {
+func (m *NodeSetServiceManager) StakeWise_UploadSignedExitMessages(ctx context.Context, deployment string, vault common.Address, exitData []nscommon.ExitData) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -241,7 +241,7 @@ func (m *NodeSetServiceManager) StakeWise_UploadSignedExitMessages(ctx context.C
 
 	// Run the request
 	err := m.runRequest(ctx, func(ctx context.Context) error {
-		return m.v2Client.StakeWise.Validators_Patch(ctx, logger.Logger, m.resources.DeploymentName, vault, exitData)
+		return m.v2Client.StakeWise.Validators_Patch(ctx, logger.Logger, deployment, vault, exitData)
 	})
 	if err != nil {
 		return fmt.Errorf("error uploading signed exit messages: %w", err)
@@ -255,7 +255,7 @@ func (m *NodeSetServiceManager) StakeWise_UploadSignedExitMessages(ctx context.C
 
 // Gets the address that has been registered by the node's user for Constellation.
 // Returns nil if the user hasn't registered with NodeSet for Constellation usage yet.
-func (m *NodeSetServiceManager) Constellation_GetRegisteredAddress(ctx context.Context) (*common.Address, error) {
+func (m *NodeSetServiceManager) Constellation_GetRegisteredAddress(ctx context.Context, deployment string) (*common.Address, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -270,7 +270,7 @@ func (m *NodeSetServiceManager) Constellation_GetRegisteredAddress(ctx context.C
 	var data v2constellation.Whitelist_GetData
 	err := m.runRequest(ctx, func(ctx context.Context) error {
 		var err error
-		data, err = m.v2Client.Constellation.Whitelist_Get(ctx, logger.Logger, m.resources.HyperdriveResources.DeploymentName)
+		data, err = m.v2Client.Constellation.Whitelist_Get(ctx, logger.Logger, deployment)
 		return err
 	})
 	if err != nil {
@@ -289,7 +289,7 @@ func (m *NodeSetServiceManager) Constellation_GetRegisteredAddress(ctx context.C
 }
 
 // Gets a signature for registering / whitelisting the node with the Constellation contracts
-func (m *NodeSetServiceManager) Constellation_GetRegistrationSignature(ctx context.Context) ([]byte, error) {
+func (m *NodeSetServiceManager) Constellation_GetRegistrationSignature(ctx context.Context, deployment string) ([]byte, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -304,7 +304,7 @@ func (m *NodeSetServiceManager) Constellation_GetRegistrationSignature(ctx conte
 	var data v2constellation.Whitelist_PostData
 	err := m.runRequest(ctx, func(ctx context.Context) error {
 		var err error
-		data, err = m.v2Client.Constellation.Whitelist_Post(ctx, logger.Logger, m.resources.HyperdriveResources.DeploymentName)
+		data, err = m.v2Client.Constellation.Whitelist_Post(ctx, logger.Logger, deployment)
 		return err
 	})
 	if err != nil {
@@ -320,7 +320,7 @@ func (m *NodeSetServiceManager) Constellation_GetRegistrationSignature(ctx conte
 }
 
 // Gets the deposit signature for a minipool from the Constellation contracts
-func (m *NodeSetServiceManager) Constellation_GetDepositSignature(ctx context.Context, minipoolAddress common.Address, salt *big.Int) ([]byte, error) {
+func (m *NodeSetServiceManager) Constellation_GetDepositSignature(ctx context.Context, deployment string, minipoolAddress common.Address, salt *big.Int) ([]byte, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -335,7 +335,7 @@ func (m *NodeSetServiceManager) Constellation_GetDepositSignature(ctx context.Co
 	logger.Debug("Getting minipool deposit signature")
 	err := m.runRequest(ctx, func(ctx context.Context) error {
 		var err error
-		data, err = m.v2Client.Constellation.MinipoolDepositSignature(ctx, logger.Logger, m.resources.HyperdriveResources.DeploymentName, minipoolAddress, salt)
+		data, err = m.v2Client.Constellation.MinipoolDepositSignature(ctx, logger.Logger, deployment, minipoolAddress, salt)
 		return err
 	})
 	if err != nil {
@@ -351,7 +351,7 @@ func (m *NodeSetServiceManager) Constellation_GetDepositSignature(ctx context.Co
 }
 
 // Get the validators that NodeSet has on record for this node
-func (m *NodeSetServiceManager) Constellation_GetValidators(ctx context.Context) ([]v2constellation.ValidatorStatus, error) {
+func (m *NodeSetServiceManager) Constellation_GetValidators(ctx context.Context, deployment string) ([]v2constellation.ValidatorStatus, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -366,7 +366,7 @@ func (m *NodeSetServiceManager) Constellation_GetValidators(ctx context.Context)
 	logger.Debug("Getting validators for node")
 	err := m.runRequest(ctx, func(ctx context.Context) error {
 		var err error
-		data, err = m.v2Client.Constellation.Validators_Get(ctx, logger.Logger, m.resources.HyperdriveResources.DeploymentName)
+		data, err = m.v2Client.Constellation.Validators_Get(ctx, logger.Logger, deployment)
 		return err
 	})
 	if err != nil {
@@ -376,7 +376,7 @@ func (m *NodeSetServiceManager) Constellation_GetValidators(ctx context.Context)
 }
 
 // Upload signed exit messages for Constellation minipools to the NodeSet service
-func (m *NodeSetServiceManager) Constellation_UploadSignedExitMessages(ctx context.Context, exitMessages []nscommon.ExitData) error {
+func (m *NodeSetServiceManager) Constellation_UploadSignedExitMessages(ctx context.Context, deployment string, exitMessages []nscommon.ExitData) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -389,7 +389,7 @@ func (m *NodeSetServiceManager) Constellation_UploadSignedExitMessages(ctx conte
 	// Run the request
 	logger.Debug("Submitting signed exit messages to nodeset")
 	err := m.runRequest(ctx, func(ctx context.Context) error {
-		return m.v2Client.Constellation.Validators_Patch(ctx, logger.Logger, m.resources.HyperdriveResources.DeploymentName, exitMessages)
+		return m.v2Client.Constellation.Validators_Patch(ctx, logger.Logger, deployment, exitMessages)
 	})
 	if err != nil {
 		return fmt.Errorf("error submitting signed exit messages: %w", err)

--- a/internal/tests/api/with-ns-registered/constellation_test.go
+++ b/internal/tests/api/with-ns-registered/constellation_test.go
@@ -16,6 +16,7 @@ const (
 	whitelistAddressString     string = "0xA9e6Bfa2BF53dE88FEb19761D9b2eE2e821bF1Bf"
 	expectedWhitelistSignature string = "0xf2b73cd729a9b15e8f17ce0189c4ddfe63ad35917f63e2b1ffa7ea1dc527bdf535ba05ba44d2dce733096b8c389472e81a4548b1d75a600633c4ac4bcb8e7c6f1b"
 	expectedMinipoolCount      int    = 10
+	deploymentName                    = "localtest"
 )
 
 // Test getting a signature for whitelisting a node
@@ -38,7 +39,7 @@ func TestConstellationWhitelistSignature(t *testing.T) {
 	nsMgr := testMgr.GetNodeSetMockServer().GetManager()
 	nsDB := nsMgr.GetDatabase()
 	deployment := nsDB.Constellation.AddDeployment(
-		res.DeploymentName,
+		deploymentName,
 		new(big.Int).SetUint64(uint64(res.ChainID)),
 		common.HexToAddress(whitelistAddressString),
 		common.Address{},
@@ -47,7 +48,7 @@ func TestConstellationWhitelistSignature(t *testing.T) {
 
 	// Get a whitelist signature
 	hd := hdNode.GetApiClient()
-	response, err := hd.NodeSet_Constellation.GetRegistrationSignature()
+	response, err := hd.NodeSet_Constellation.GetRegistrationSignature(deploymentName)
 	require.NoError(t, err)
 	require.False(t, response.Data.NotAuthorized)
 	require.False(t, response.Data.NotRegistered)

--- a/server/api/nodeset/constellation/get-deposit-signature.go
+++ b/server/api/nodeset/constellation/get-deposit-signature.go
@@ -31,6 +31,7 @@ func (f *constellationGetDepositSignatureContextFactory) Create(args url.Values)
 		handler: f.handler,
 	}
 	inputErrs := []error{
+		server.GetStringFromVars("deployment", args, &c.deployment),
 		server.ValidateArg("minipoolAddress", args, input.ValidateAddress, &c.minipoolAddress),
 		server.ValidateArg("salt", args, input.ValidateBigInt, &c.salt),
 	}
@@ -49,6 +50,7 @@ func (f *constellationGetDepositSignatureContextFactory) RegisterRoute(router *m
 type constellationGetDepositSignatureContext struct {
 	handler *ConstellationHandler
 
+	deployment      string
 	minipoolAddress common.Address
 	salt            *big.Int
 }
@@ -73,7 +75,7 @@ func (c *constellationGetDepositSignatureContext) PrepareData(data *api.NodeSetC
 
 	// Get the set version
 	ns := sp.GetNodeSetServiceManager()
-	signature, err := ns.Constellation_GetDepositSignature(ctx, c.minipoolAddress, c.salt)
+	signature, err := ns.Constellation_GetDepositSignature(ctx, c.deployment, c.minipoolAddress, c.salt)
 	if err != nil {
 		if errors.Is(err, v2constellation.ErrNotAuthorized) {
 			data.NotAuthorized = true

--- a/server/api/nodeset/constellation/get-registered-address.go
+++ b/server/api/nodeset/constellation/get-registered-address.go
@@ -26,7 +26,9 @@ func (f *constellationGetRegisteredAddressContextFactory) Create(args url.Values
 	c := &constellationGetRegisteredAddressContext{
 		handler: f.handler,
 	}
-	inputErrs := []error{}
+	inputErrs := []error{
+		server.GetStringFromVars("deployment", args, &c.deployment),
+	}
 	return c, errors.Join(inputErrs...)
 }
 
@@ -42,6 +44,8 @@ func (f *constellationGetRegisteredAddressContextFactory) RegisterRoute(router *
 
 type constellationGetRegisteredAddressContext struct {
 	handler *ConstellationHandler
+
+	deployment string
 }
 
 func (c *constellationGetRegisteredAddressContext) PrepareData(data *api.NodeSetConstellation_GetRegisteredAddressData, opts *bind.TransactOpts) (types.ResponseStatus, error) {
@@ -64,7 +68,7 @@ func (c *constellationGetRegisteredAddressContext) PrepareData(data *api.NodeSet
 
 	// Get the registered address
 	ns := sp.GetNodeSetServiceManager()
-	address, err := ns.Constellation_GetRegisteredAddress(ctx)
+	address, err := ns.Constellation_GetRegisteredAddress(ctx, c.deployment)
 	if err != nil {
 		return types.ResponseStatus_Error, err
 	}

--- a/server/api/nodeset/constellation/get-registration-signature.go
+++ b/server/api/nodeset/constellation/get-registration-signature.go
@@ -27,7 +27,9 @@ func (f *constellationGetRegistrationSignatureContextFactory) Create(args url.Va
 	c := &constellationGetRegistrationSignatureContext{
 		handler: f.handler,
 	}
-	inputErrs := []error{}
+	inputErrs := []error{
+		server.GetStringFromVars("deployment", args, &c.deployment),
+	}
 	return c, errors.Join(inputErrs...)
 }
 
@@ -42,6 +44,8 @@ func (f *constellationGetRegistrationSignatureContextFactory) RegisterRoute(rout
 // ===============
 type constellationGetRegistrationSignatureContext struct {
 	handler *ConstellationHandler
+
+	deployment string
 }
 
 func (c *constellationGetRegistrationSignatureContext) PrepareData(data *api.NodeSetConstellation_GetRegistrationSignatureData, opts *bind.TransactOpts) (types.ResponseStatus, error) {
@@ -64,7 +68,7 @@ func (c *constellationGetRegistrationSignatureContext) PrepareData(data *api.Nod
 
 	// Get the registration signature
 	ns := sp.GetNodeSetServiceManager()
-	signature, err := ns.Constellation_GetRegistrationSignature(ctx)
+	signature, err := ns.Constellation_GetRegistrationSignature(ctx, c.deployment)
 	if err != nil {
 		if errors.Is(err, v2constellation.ErrNotAuthorized) {
 			data.NotAuthorized = true

--- a/server/api/nodeset/constellation/get-validators.go
+++ b/server/api/nodeset/constellation/get-validators.go
@@ -27,7 +27,9 @@ func (f *constellationGetValidatorsContextFactory) Create(args url.Values) (*con
 	c := &constellationGetValidatorsContext{
 		handler: f.handler,
 	}
-	inputErrs := []error{}
+	inputErrs := []error{
+		server.GetStringFromVars("deployment", args, &c.deployment),
+	}
 	return c, errors.Join(inputErrs...)
 }
 
@@ -43,6 +45,8 @@ func (f *constellationGetValidatorsContextFactory) RegisterRoute(router *mux.Rou
 
 type constellationGetValidatorsContext struct {
 	handler *ConstellationHandler
+
+	deployment string
 }
 
 func (c *constellationGetValidatorsContext) PrepareData(data *api.NodeSetConstellation_GetValidatorsData, opts *bind.TransactOpts) (types.ResponseStatus, error) {
@@ -65,7 +69,7 @@ func (c *constellationGetValidatorsContext) PrepareData(data *api.NodeSetConstel
 
 	// Get the registered validators
 	ns := sp.GetNodeSetServiceManager()
-	validators, err := ns.Constellation_GetValidators(ctx)
+	validators, err := ns.Constellation_GetValidators(ctx, c.deployment)
 	if err != nil {
 		if errors.Is(err, v2constellation.ErrNotAuthorized) {
 			data.NotAuthorized = true

--- a/server/api/nodeset/constellation/upload-signed-exits.go
+++ b/server/api/nodeset/constellation/upload-signed-exits.go
@@ -64,7 +64,7 @@ func (c *constellationUploadSignedExitsContext) PrepareData(data *api.NodeSetCon
 
 	// Upload the deposit data
 	ns := sp.GetNodeSetServiceManager()
-	err = ns.Constellation_UploadSignedExitMessages(ctx, c.body.ExitMessages)
+	err = ns.Constellation_UploadSignedExitMessages(ctx, c.body.Deployment, c.body.ExitMessages)
 	if err != nil {
 		if errors.Is(err, v2constellation.ErrNotAuthorized) {
 			data.NotAuthorized = true

--- a/server/api/nodeset/stakewise/get-registered-validators.go
+++ b/server/api/nodeset/stakewise/get-registered-validators.go
@@ -29,6 +29,7 @@ func (f *stakeWiseGetRegisteredValidatorsContextFactory) Create(args url.Values)
 		handler: f.handler,
 	}
 	inputErrs := []error{
+		server.GetStringFromVars("deployment", args, &c.deployment),
 		server.ValidateArg("vault", args, input.ValidateAddress, &c.vault),
 	}
 	return c, errors.Join(inputErrs...)
@@ -45,7 +46,9 @@ func (f *stakeWiseGetRegisteredValidatorsContextFactory) RegisterRoute(router *m
 // ===============
 type stakeWiseGetRegisteredValidatorsContext struct {
 	handler *StakeWiseHandler
-	vault   common.Address
+
+	deployment string
+	vault      common.Address
 }
 
 func (c *stakeWiseGetRegisteredValidatorsContext) PrepareData(data *api.NodeSetStakeWise_GetRegisteredValidatorsData, opts *bind.TransactOpts) (types.ResponseStatus, error) {
@@ -68,7 +71,7 @@ func (c *stakeWiseGetRegisteredValidatorsContext) PrepareData(data *api.NodeSetS
 
 	// Get the registered validators
 	ns := sp.GetNodeSetServiceManager()
-	response, err := ns.StakeWise_GetRegisteredValidators(ctx, c.vault)
+	response, err := ns.StakeWise_GetRegisteredValidators(ctx, c.deployment, c.vault)
 	if err != nil {
 		return types.ResponseStatus_Error, err
 	}

--- a/server/api/nodeset/stakewise/get-server-deposit-data-version.go
+++ b/server/api/nodeset/stakewise/get-server-deposit-data-version.go
@@ -29,6 +29,7 @@ func (f *stakeWiseGetDepositDataSetVersionContextFactory) Create(args url.Values
 		handler: f.handler,
 	}
 	inputErrs := []error{
+		server.GetStringFromVars("deployment", args, &c.deployment),
 		server.ValidateArg("vault", args, input.ValidateAddress, &c.vault),
 	}
 	return c, errors.Join(inputErrs...)
@@ -45,7 +46,9 @@ func (f *stakeWiseGetDepositDataSetVersionContextFactory) RegisterRoute(router *
 // ===============
 type stakeWiseGetDepositDataSetVersionContext struct {
 	handler *StakeWiseHandler
-	vault   common.Address
+
+	deployment string
+	vault      common.Address
 }
 
 func (c *stakeWiseGetDepositDataSetVersionContext) PrepareData(data *api.NodeSetStakeWise_GetDepositDataSetVersionData, opts *bind.TransactOpts) (types.ResponseStatus, error) {
@@ -68,7 +71,7 @@ func (c *stakeWiseGetDepositDataSetVersionContext) PrepareData(data *api.NodeSet
 
 	// Get the set version
 	ns := sp.GetNodeSetServiceManager()
-	version, err := ns.StakeWise_GetServerDepositDataVersion(ctx, c.vault)
+	version, err := ns.StakeWise_GetServerDepositDataVersion(ctx, c.deployment, c.vault)
 	if err != nil {
 		return types.ResponseStatus_Error, err
 	}

--- a/server/api/nodeset/stakewise/get-server-deposit-data.go
+++ b/server/api/nodeset/stakewise/get-server-deposit-data.go
@@ -29,6 +29,7 @@ func (f *stakeWiseGetDepositDataSetContextFactory) Create(args url.Values) (*sta
 		handler: f.handler,
 	}
 	inputErrs := []error{
+		server.GetStringFromVars("deployment", args, &c.deployment),
 		server.ValidateArg("vault", args, input.ValidateAddress, &c.vault),
 	}
 	return c, errors.Join(inputErrs...)
@@ -45,7 +46,9 @@ func (f *stakeWiseGetDepositDataSetContextFactory) RegisterRoute(router *mux.Rou
 // ===============
 type stakeWiseGetDepositDataSetContext struct {
 	handler *StakeWiseHandler
-	vault   common.Address
+
+	deployment string
+	vault      common.Address
 }
 
 func (c *stakeWiseGetDepositDataSetContext) PrepareData(data *api.NodeSetStakeWise_GetDepositDataSetData, opts *bind.TransactOpts) (types.ResponseStatus, error) {
@@ -68,7 +71,7 @@ func (c *stakeWiseGetDepositDataSetContext) PrepareData(data *api.NodeSetStakeWi
 
 	// Get the set version
 	ns := sp.GetNodeSetServiceManager()
-	version, set, err := ns.StakeWise_GetServerDepositData(ctx, c.vault)
+	version, set, err := ns.StakeWise_GetServerDepositData(ctx, c.deployment, c.vault)
 	if err != nil {
 		return types.ResponseStatus_Error, err
 	}

--- a/server/api/nodeset/stakewise/upload-deposit-data.go
+++ b/server/api/nodeset/stakewise/upload-deposit-data.go
@@ -64,7 +64,7 @@ func (c *stakeWiseUploadDepositDataContext) PrepareData(data *api.NodeSetStakeWi
 
 	// Upload the deposit data
 	ns := sp.GetNodeSetServiceManager()
-	err = ns.StakeWise_UploadDepositData(ctx, c.body.Vault, c.body.DepositData)
+	err = ns.StakeWise_UploadDepositData(ctx, c.body.Deployment, c.body.Vault, c.body.DepositData)
 	if err != nil {
 		if errors.Is(err, apiv0.ErrVaultNotFound) {
 			data.VaultNotFound = true

--- a/server/api/nodeset/stakewise/upload-signed-exits.go
+++ b/server/api/nodeset/stakewise/upload-signed-exits.go
@@ -62,7 +62,7 @@ func (c *stakeWiseUploadSignedExitsContext) PrepareData(data *api.NodeSetStakeWi
 
 	// Upload the deposit data
 	ns := sp.GetNodeSetServiceManager()
-	err = ns.StakeWise_UploadSignedExitMessages(ctx, c.body.Vault, c.body.ExitData)
+	err = ns.StakeWise_UploadSignedExitMessages(ctx, c.body.Deployment, c.body.Vault, c.body.ExitData)
 	if err != nil {
 		return types.ResponseStatus_Error, err
 	}

--- a/shared/config/resources.go
+++ b/shared/config/resources.go
@@ -17,12 +17,6 @@ const (
 
 	// The nodeset.io URL for development / staging
 	NodesetUrlStaging string = "https://staging.nodeset.io/api"
-
-	// The deployment name for Mainnet
-	NodesetDeploymentMainnet string = "mainnet"
-
-	// The deployment name for Holesky testing
-	NodesetDeploymentHolesky string = "holesky"
 )
 
 var (
@@ -54,9 +48,6 @@ type HyperdriveSettings struct {
 type HyperdriveResources struct {
 	// The URL for the NodeSet API server
 	NodeSetApiUrl string `yaml:"nodeSetApiUrl" json:"nodeSetApiUrl"`
-
-	// The name of the deployment used by this instance of Hyperdrive
-	DeploymentName string `yaml:"deploymentName" json:"deploymentName"`
 }
 
 // An aggregated collection of resources for the selected network, including Hyperdrive resources

--- a/shared/types/api/nodeset_constellation.go
+++ b/shared/types/api/nodeset_constellation.go
@@ -33,6 +33,7 @@ type NodeSetConstellation_GetValidatorsData struct {
 }
 
 type NodeSetConstellation_UploadSignedExitsRequestBody struct {
+	Deployment   string              `json:"deployment"`
 	ExitMessages []nscommon.ExitData `json:"exitMessages"`
 }
 

--- a/shared/types/api/nodeset_stakewise.go
+++ b/shared/types/api/nodeset_stakewise.go
@@ -24,6 +24,7 @@ type NodeSetStakeWise_GetDepositDataSetData struct {
 }
 
 type NodeSetStakeWise_UploadDepositDataRequestBody struct {
+	Deployment  string                       `json:"deployment"`
 	Vault       common.Address               `json:"vault"`
 	DepositData []beacon.ExtendedDepositData `json:"depositData"`
 }
@@ -35,8 +36,9 @@ type NodeSetStakeWise_UploadDepositDataData struct {
 }
 
 type NodeSetStakeWise_UploadSignedExitsRequestBody struct {
-	Vault    common.Address      `json:"vault"`
-	ExitData []nscommon.ExitData `json:"exitData"`
+	Deployment string              `json:"deployment"`
+	Vault      common.Address      `json:"vault"`
+	ExitData   []nscommon.ExitData `json:"exitData"`
 }
 
 type NodeSetStakeWise_UploadSignedExitsData struct {

--- a/testing/test-manager.go
+++ b/testing/test-manager.go
@@ -74,7 +74,7 @@ func NewHyperdriveTestManagerWithDefaults(netSettingsProvisioner NetworkSettings
 	beaconCfg := tm.GetBeaconMockManager().GetConfig()
 	networkSettings := GetDefaultTestNetworkSettings(beaconCfg)
 	networkSettings = netSettingsProvisioner(networkSettings)
-	resources := getTestResources(networkSettings.NetworkResources, fmt.Sprintf("http://%s:%d/api/", "localhost", nodesetMock.GetPort()), "localtest")
+	resources := getTestResources(networkSettings.NetworkResources, fmt.Sprintf("http://%s:%d/api/", "localhost", nodesetMock.GetPort()))
 	hdNetSettings := &hdconfig.HyperdriveSettings{
 		NetworkSettings:     networkSettings,
 		HyperdriveResources: resources.HyperdriveResources,

--- a/testing/test-resources.go
+++ b/testing/test-resources.go
@@ -27,12 +27,11 @@ func GetDefaultTestNetworkSettings(beaconConfig *db.Config) *config.NetworkSetti
 }
 
 // Returns a network resources instance with local testing network values
-func getTestResources(networkResources *config.NetworkResources, nodesetUrl string, deploymentName string) *hdconfig.MergedResources {
+func getTestResources(networkResources *config.NetworkResources, nodesetUrl string) *hdconfig.MergedResources {
 	return &hdconfig.MergedResources{
 		NetworkResources: networkResources,
 		HyperdriveResources: &hdconfig.HyperdriveResources{
-			NodeSetApiUrl:  nodesetUrl,
-			DeploymentName: deploymentName,
+			NodeSetApiUrl: nodesetUrl,
 		},
 	}
 }


### PR DESCRIPTION
This moves nodeset.io deployments from the daemon (a one-deployment-for-all design) into the modules so each module can govern its own deployment names.