### PR TITLE
Add encryption support

### DIFF
--- a/client/nodeset-constellation.go
+++ b/client/nodeset-constellation.go
@@ -66,7 +66,7 @@ func (r *NodeSetConstellationRequester) GetValidators(deployment string) (*types
 }
 
 // Uploads signed exit messages to the NodeSet service
-func (r *NodeSetConstellationRequester) UploadSignedExits(deployment string, exitMessages []nscommon.ExitData) (*types.ApiResponse[api.NodeSetConstellation_UploadSignedExitsData], error) {
+func (r *NodeSetConstellationRequester) UploadSignedExits(deployment string, exitMessages []nscommon.EncryptedExitData) (*types.ApiResponse[api.NodeSetConstellation_UploadSignedExitsData], error) {
 	body := api.NodeSetConstellation_UploadSignedExitsRequestBody{
 		Deployment:   deployment,
 		ExitMessages: exitMessages,

--- a/client/nodeset-stakewise.go
+++ b/client/nodeset-stakewise.go
@@ -68,7 +68,7 @@ func (r *NodeSetStakeWiseRequester) UploadDepositData(deployment string, vault c
 }
 
 // Uploads signed exit messages to the NodeSet service
-func (r *NodeSetStakeWiseRequester) UploadSignedExits(deployment string, vault common.Address, data []nscommon.ExitData) (*types.ApiResponse[api.NodeSetStakeWise_UploadSignedExitsData], error) {
+func (r *NodeSetStakeWiseRequester) UploadSignedExits(deployment string, vault common.Address, data []nscommon.EncryptedExitData) (*types.ApiResponse[api.NodeSetStakeWise_UploadSignedExitsData], error) {
 	body := api.NodeSetStakeWise_UploadSignedExitsRequestBody{
 		Deployment: deployment,
 		Vault:      vault,

--- a/common/nodeset-manager.go
+++ b/common/nodeset-manager.go
@@ -228,7 +228,7 @@ func (m *NodeSetServiceManager) StakeWise_GetRegisteredValidators(ctx context.Co
 }
 
 // Uploads signed exit messages set to the server
-func (m *NodeSetServiceManager) StakeWise_UploadSignedExitMessages(ctx context.Context, deployment string, vault common.Address, exitData []nscommon.ExitData) error {
+func (m *NodeSetServiceManager) StakeWise_UploadSignedExitMessages(ctx context.Context, deployment string, vault common.Address, exitData []nscommon.EncryptedExitData) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -376,7 +376,7 @@ func (m *NodeSetServiceManager) Constellation_GetValidators(ctx context.Context,
 }
 
 // Upload signed exit messages for Constellation minipools to the NodeSet service
-func (m *NodeSetServiceManager) Constellation_UploadSignedExitMessages(ctx context.Context, deployment string, exitMessages []nscommon.ExitData) error {
+func (m *NodeSetServiceManager) Constellation_UploadSignedExitMessages(ctx context.Context, deployment string, exitMessages []nscommon.EncryptedExitData) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/gorilla/mux v1.8.1
 	github.com/hashicorp/go-version v1.6.0
-	github.com/nodeset-org/nodeset-client-go v1.1.1-0.20241007162432-cba11fc62963
+	github.com/nodeset-org/nodeset-client-go v1.2.0
 	github.com/nodeset-org/osha v0.3.1
 	github.com/rocket-pool/batch-query v1.0.0
 	github.com/rocket-pool/node-manager-core v0.5.2-0.20241003024529-05c829d805c6

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22
 toolchain go1.22.7
 
 require (
+	filippo.io/age v1.2.0
 	github.com/alessio/shellescape v1.4.2
 	github.com/docker/docker v27.3.1+incompatible
 	github.com/ethereum/go-ethereum v1.14.8
@@ -13,7 +14,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/gorilla/mux v1.8.1
 	github.com/hashicorp/go-version v1.6.0
-	github.com/nodeset-org/nodeset-client-go v1.1.0
+	github.com/nodeset-org/nodeset-client-go v1.1.1-0.20241007162432-cba11fc62963
 	github.com/nodeset-org/osha v0.3.1
 	github.com/rocket-pool/batch-query v1.0.0
 	github.com/rocket-pool/node-manager-core v0.5.2-0.20241003024529-05c829d805c6

--- a/go.sum
+++ b/go.sum
@@ -364,8 +364,8 @@ github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOEL
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nodeset-org/nodeset-client-go v1.1.1-0.20241007162432-cba11fc62963 h1:DhjPEnbtzPUEG+/INKjNHs7Q5JYA2aUURttcOD4WvGI=
-github.com/nodeset-org/nodeset-client-go v1.1.1-0.20241007162432-cba11fc62963/go.mod h1:TATOnCsIvDjC7C+h1izgw0+t35N40Hr/CxhgaLK78e4=
+github.com/nodeset-org/nodeset-client-go v1.2.0 h1:16GfFTkjMdgGiAdXWyLLMnLVHd+E6Rh+UYzS1i8/o+I=
+github.com/nodeset-org/nodeset-client-go v1.2.0/go.mod h1:TATOnCsIvDjC7C+h1izgw0+t35N40Hr/CxhgaLK78e4=
 github.com/nodeset-org/osha v0.3.1 h1:xHDjCswxGDazY/UsZ0QOpcu7gTVnEuUwXcKGVAz72lI=
 github.com/nodeset-org/osha v0.3.1/go.mod h1:47D6kYMuxYDTbul3w/YtE1LKA0hfzbXzCEC3M9oQlOU=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
+c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805 h1:u2qwJeEvnypw+OCPUHmoZE3IqwfuN5kgDfo5MLzpNM0=
+c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805/go.mod h1:FomMrUJ2Lxt5jCLmZkG3FHa72zUprnhd3v/Z18Snm4w=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 contrib.go.opencensus.io/exporter/jaeger v0.2.1 h1:yGBYzYMewVL0yO9qqJv3Z5+IRhPdU7e9o/2oKpX4YvI=
 contrib.go.opencensus.io/exporter/jaeger v0.2.1/go.mod h1:Y8IsLgdxqh1QxYxPC5IgXVmBaeLUeQFfBeBi9PbeZd0=
+filippo.io/age v1.2.0 h1:vRDp7pUMaAJzXNIWJVAZnEf/Dyi4Vu4wI8S1LBzufhE=
+filippo.io/age v1.2.0/go.mod h1:JL9ew2lTN+Pyft4RiNGguFfOpewKwSHm5ayKD/A4004=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240716105424-66b64c4bb379 h1:shYAfOpsleWVaSwGxQjmi+BBIwzj5jxB1FTCpVqs0N8=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240716105424-66b64c4bb379/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20231105174938-2b5cbb29f3e2 h1:dIScnXFlF784X79oi7MzVT6GWqr/W1uUt0pB5CsDs9M=
@@ -360,8 +364,8 @@ github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOEL
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nodeset-org/nodeset-client-go v1.1.0 h1:VjpU8FmRm+K37BRuHpBSO+nl4VWsc2etCmtxVpvchtk=
-github.com/nodeset-org/nodeset-client-go v1.1.0/go.mod h1:slpwejkJ/vYU9SKA3SYw4hIPJLzDUeQxcx+Cm04kkIA=
+github.com/nodeset-org/nodeset-client-go v1.1.1-0.20241007162432-cba11fc62963 h1:DhjPEnbtzPUEG+/INKjNHs7Q5JYA2aUURttcOD4WvGI=
+github.com/nodeset-org/nodeset-client-go v1.1.1-0.20241007162432-cba11fc62963/go.mod h1:TATOnCsIvDjC7C+h1izgw0+t35N40Hr/CxhgaLK78e4=
 github.com/nodeset-org/osha v0.3.1 h1:xHDjCswxGDazY/UsZ0QOpcu7gTVnEuUwXcKGVAz72lI=
 github.com/nodeset-org/osha v0.3.1/go.mod h1:47D6kYMuxYDTbul3w/YtE1LKA0hfzbXzCEC3M9oQlOU=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/shared/config/resources.go
+++ b/shared/config/resources.go
@@ -48,6 +48,9 @@ type HyperdriveSettings struct {
 type HyperdriveResources struct {
 	// The URL for the NodeSet API server
 	NodeSetApiUrl string `yaml:"nodeSetApiUrl" json:"nodeSetApiUrl"`
+
+	// The pubkey used to encrypt messages to nodeset.io
+	EncryptionPubkey string `yaml:"encryptionPubkey" json:"encryptionPubkey"`
 }
 
 // An aggregated collection of resources for the selected network, including Hyperdrive resources

--- a/shared/types/api/nodeset_constellation.go
+++ b/shared/types/api/nodeset_constellation.go
@@ -33,8 +33,8 @@ type NodeSetConstellation_GetValidatorsData struct {
 }
 
 type NodeSetConstellation_UploadSignedExitsRequestBody struct {
-	Deployment   string              `json:"deployment"`
-	ExitMessages []nscommon.ExitData `json:"exitMessages"`
+	Deployment   string                       `json:"deployment"`
+	ExitMessages []nscommon.EncryptedExitData `json:"exitMessages"`
 }
 
 type NodeSetConstellation_UploadSignedExitsData struct {

--- a/shared/types/api/nodeset_stakewise.go
+++ b/shared/types/api/nodeset_stakewise.go
@@ -36,9 +36,9 @@ type NodeSetStakeWise_UploadDepositDataData struct {
 }
 
 type NodeSetStakeWise_UploadSignedExitsRequestBody struct {
-	Deployment string              `json:"deployment"`
-	Vault      common.Address      `json:"vault"`
-	ExitData   []nscommon.ExitData `json:"exitData"`
+	Deployment string                       `json:"deployment"`
+	Vault      common.Address               `json:"vault"`
+	ExitData   []nscommon.EncryptedExitData `json:"exitData"`
 }
 
 type NodeSetStakeWise_UploadSignedExitsData struct {

--- a/shared/version.go
+++ b/shared/version.go
@@ -1,5 +1,5 @@
 package shared
 
 const (
-	HyperdriveVersion string = "1.1.0-b2"
+	HyperdriveVersion string = "1.1.0-dev"
 )

--- a/testing/test-resources.go
+++ b/testing/test-resources.go
@@ -1,13 +1,23 @@
 package testing
 
 import (
+	"filippo.io/age"
 	hdconfig "github.com/nodeset-org/hyperdrive-daemon/shared/config"
 	"github.com/nodeset-org/osha/beacon/db"
 	"github.com/rocket-pool/node-manager-core/config"
 )
 
 const (
+	// ETH network name to use for test networks
 	TestNetworkEthName string = "hardhat"
+
+	// Serialized nodeset.io deployment dummy encryption ID
+	EncryptionIdentityString string = "AGE-SECRET-KEY-19N32FTRU5JJ66DNTVE8NTTE04CUQC3R3FC5QD9QKA97AZWCUW74ST78LD3"
+)
+
+var (
+	// Nodeset.io deployment dummy encryption ID
+	EncryptionIdentity, _ = age.ParseX25519Identity(EncryptionIdentityString)
 )
 
 // Creates a new set of network settings designed for usage in local testing with Hardat.
@@ -31,7 +41,8 @@ func getTestResources(networkResources *config.NetworkResources, nodesetUrl stri
 	return &hdconfig.MergedResources{
 		NetworkResources: networkResources,
 		HyperdriveResources: &hdconfig.HyperdriveResources{
-			NodeSetApiUrl: nodesetUrl,
+			NodeSetApiUrl:    nodesetUrl,
+			EncryptionPubkey: EncryptionIdentity.Recipient().String(),
 		},
 	}
 }


### PR DESCRIPTION
This has parity with the updated v2 API, by adding support for encrypting certain data that will be sent to nodeset.io via [age](https://github.com/FiloSottile/age). Signed exit messages will now be encrypted prior to sending. Credit goes to @poupas for suggesting this feature!