### PR TITLE
Remove Holesky support

### DIFF
--- a/shared/config/enums.go
+++ b/shared/config/enums.go
@@ -5,9 +5,6 @@ import (
 )
 
 const (
-	// The NodeSet dev network on Holesky
-	Network_HoleskyDev config.Network = "holesky-dev"
-
 	// Local test network for development
 	Network_LocalTest config.Network = "local-test"
 )

--- a/shared/config/hyperdrive-config.go
+++ b/shared/config/hyperdrive-config.go
@@ -149,7 +149,7 @@ func NewHyperdriveConfigForNetwork(hdDir string, networks []*HyperdriveSettings,
 			ParameterCommon: &config.ParameterCommon{
 				ID:                 ids.NetworkID,
 				Name:               "Network",
-				Description:        "The Ethereum network you want to use - select Hoodi Testnet or Holesky Testnet to practice with fake ETH, or Mainnet to stake on the real network using real ETH.",
+				Description:        "The Ethereum network you want to use - select Hoodi Testnet to practice with fake ETH, or Mainnet to stake on the real network using real ETH.",
 				AffectsContainers:  []config.ContainerID{config.ContainerID_Daemon, config.ContainerID_ExecutionClient, config.ContainerID_BeaconNode, config.ContainerID_ValidatorClient, config.ContainerID_MevBoost},
 				CanBeBlank:         false,
 				OverwriteOnUpgrade: false,
@@ -494,7 +494,7 @@ func getNetworkOptions(networks []*HyperdriveSettings) []*config.ParameterOption
 		})
 	}
 
-	// Sort the options so mainnet comes first, Hoodi comes second, and holesky comes third
+	// Sort the options so mainnet comes first and Hoodi comes second
 	sort.SliceStable(options, func(i, j int) bool {
 		firstOption := options[i]
 		secondOption := options[j]
@@ -512,14 +512,6 @@ func getNetworkOptions(networks []*HyperdriveSettings) []*config.ParameterOption
 			return true
 		}
 		if secondOption.Value == config.Network_Hoodi {
-			return false
-		}
-
-		// Holesky comes third
-		if firstOption.Value == config.Network_Holesky {
-			return true
-		}
-		if secondOption.Value == config.Network_Holesky {
 			return false
 		}
 

--- a/shared/config/mev-boost-config.go
+++ b/shared/config/mev-boost-config.go
@@ -214,9 +214,8 @@ func NewMevBoostConfig(parent *HyperdriveConfig) *MevBoostConfig {
 				OverwriteOnUpgrade: true,
 			},
 			Default: map[config.Network]string{
-				config.Network_Hoodi:   mevBoostTestTag,
-				config.Network_Holesky: mevBoostTestTag,
-				config.Network_All:     mevBoostProdTag,
+				config.Network_Hoodi: mevBoostTestTag,
+				config.Network_All:   mevBoostProdTag,
 			},
 		},
 

--- a/shared/config/resources.go
+++ b/shared/config/resources.go
@@ -25,16 +25,6 @@ var (
 		NodeSetApiUrl: NodesetUrlProd,
 	}
 
-	// Holesky resources for reference in testing
-	HoleskyResourcesReference *HyperdriveResources = &HyperdriveResources{
-		NodeSetApiUrl: NodesetUrlProd,
-	}
-
-	// Holesky Devnet resources for reference in testing
-	HoleskyDevResourcesReference *HyperdriveResources = &HyperdriveResources{
-		NodeSetApiUrl: NodesetUrlStaging,
-	}
-
 	// Hoodi resources for reference in testing
 	HoodiResourcesReference *HyperdriveResources = &HyperdriveResources{
 		NodeSetApiUrl: NodesetUrlProd,


### PR DESCRIPTION
This removes Holesky from the list of networks with baked-in parameters. It will still work if people add the network resource files manually.